### PR TITLE
feat: add TwelveLabs (Marengo + Pegasus) support

### DIFF
--- a/VideoRAG-algorithm/README.md
+++ b/VideoRAG-algorithm/README.md
@@ -25,6 +25,7 @@
 - [🚀 Quick Start](#-quick-start)
 - [🧪 Experiments](#-experiments)
 - [🦙 Ollama Support](#-ollama-support)
+- [☁️ TwelveLabs Support](#️-twelvelabs-support)
 - [📖 Citation](#-citation)
 - [🙏 Acknowledgement](#-acknowledgement)
 
@@ -86,6 +87,9 @@ pip install ctranslate2==4.4.0 faster_whisper==1.0.3 neo4j hnswlib xxhash nano-v
 pip install transformers==4.37.1
 pip install tiktoken openai tenacity
 pip install ollama==0.5.3
+
+# (Optional) TwelveLabs cloud video understanding — Marengo embeddings + Pegasus captioning
+pip install twelvelabs>=1.2.8
 ```
 
 ### 📥 Model Checkpoints
@@ -307,6 +311,57 @@ And specify the config when creating your VideoRag instance
 ### Jupyter Notebook
 To  test the solution on a single video, just load the notebook in the [notebook folder](VideoRAG/nodebooks) and
 update the paramters to fit your situation.
+
+## ☁️ TwelveLabs Support
+
+VideoRAG can optionally use [TwelveLabs](https://twelvelabs.io) for the visual
+retrieval layer and for clip-level captioning, instead of the local ImageBind /
+MiniCPM-V models. This removes the local GPU requirement for those two steps. It
+is **fully opt-in** — the defaults are unchanged.
+
+- **Marengo** produces video-segment and text-query embeddings in a shared
+  512-d space, so it is a drop-in replacement for the ImageBind visual index.
+- **Pegasus** reads the video directly and returns a natural-language caption /
+  answer, replacing MiniCPM-V for clip-level captioning / QA.
+
+Install the SDK and export your key (a generous free tier is available):
+
+```bash
+pip install twelvelabs>=1.2.8
+export TWELVELABS_API_KEY="your-key"   # grab one at https://twelvelabs.io
+```
+
+Use Marengo for the visual segment index by swapping the segment feature store
+when you create your `VideoRAG` instance (Marengo embeddings are 512-d):
+
+```python
+from videorag import VideoRAG
+from videorag._llm import openai_4o_mini_config
+from videorag._storage import TwelveLabsVideoSegmentStorage
+
+videorag = VideoRAG(
+    llm=openai_4o_mini_config,
+    vs_vector_db_storage_cls=TwelveLabsVideoSegmentStorage,
+    video_embedding_dim=512,
+    working_dir="./videorag-workdir",
+)
+```
+
+For Pegasus captioning of an individual clip (e.g. a public URL or an uploaded
+asset id):
+
+```python
+from twelvelabs import TwelveLabs
+from twelvelabs.types import VideoContext_Url
+from videorag._videoutil import tl_segment_caption
+
+client = TwelveLabs(api_key="...")
+caption = tl_segment_caption(
+    client,
+    VideoContext_Url(url="https://example.com/clip.mp4"),
+    prompt="Describe what happens in this clip.",
+)
+```
 
 ## 📖 Citation
 If you find this work is helpful to your research, please consider citing our paper:

--- a/VideoRAG-algorithm/tests/test_twelvelabs.py
+++ b/VideoRAG-algorithm/tests/test_twelvelabs.py
@@ -1,0 +1,162 @@
+"""Tests for the optional TwelveLabs (Marengo + Pegasus) integration.
+
+The no-network tests use a small fake TwelveLabs client and only require
+``torch``; the live tests are skipped unless ``TWELVELABS_API_KEY`` is set.
+
+Run from ``VideoRAG-algorithm/``::
+
+    pytest tests/test_twelvelabs.py
+"""
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+# The TwelveLabs helpers only need ``torch`` at runtime, but they live in modules
+# whose top-level imports also pull in the heavy local-inference stack (ImageBind,
+# transformers, moviepy, PIL). Stub those out so the no-network tests can run in a
+# lightweight CI environment, then load the two leaf modules straight from file.
+_REPO = os.path.dirname(os.path.dirname(__file__))
+
+
+def _stub(name, **attrs):
+    if name in sys.modules:
+        return
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+
+
+for _m in ["imagebind", "imagebind.data", "moviepy", "moviepy.video",
+           "moviepy.video.io", "transformers", "PIL"]:
+    _stub(_m)
+_stub("imagebind.models")
+_stub("imagebind.models.imagebind_model", ImageBindModel=object, ModalityType=object,
+      imagebind_huge=lambda *a, **k: None)
+sys.modules["imagebind"].data = sys.modules["imagebind.data"]
+sys.modules["imagebind"].models = sys.modules["imagebind.models"]
+sys.modules["imagebind.models"].imagebind_model = sys.modules["imagebind.models.imagebind_model"]
+_stub("moviepy.video.io.VideoFileClip", VideoFileClip=object)
+sys.modules["moviepy.video.io"].VideoFileClip = sys.modules["moviepy.video.io.VideoFileClip"]
+sys.modules["transformers"].AutoModel = object
+sys.modules["transformers"].AutoTokenizer = object
+sys.modules["PIL"].Image = object
+
+
+def _load(rel_path, mod_name):
+    spec = importlib.util.spec_from_file_location(mod_name, os.path.join(_REPO, rel_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_feature = _load("videorag/_videoutil/feature.py", "_tl_feature")
+_caption = _load("videorag/_videoutil/caption.py", "_tl_caption")
+tl_encode_string_query = _feature.tl_encode_string_query
+tl_encode_video_segments = _feature.tl_encode_video_segments
+tl_segment_caption = _caption.tl_segment_caption
+
+EMBED_DIM = 512
+
+
+class _FakeSegment:
+    def __init__(self, vector, scope):
+        self.float_ = vector
+        self.embedding_scope = scope
+
+
+class _FakeTextEmbedding:
+    def __init__(self):
+        self.segments = [_FakeSegment([0.1] * EMBED_DIM, "text")]
+
+
+class _FakeVideoEmbedding:
+    def __init__(self):
+        self.segments = [
+            _FakeSegment([0.2] * EMBED_DIM, "clip"),
+            _FakeSegment([0.4] * EMBED_DIM, "video"),
+        ]
+
+
+class _FakeTask:
+    id = "task-123"
+
+
+class _FakeEmbedTasks:
+    def create(self, **kwargs):
+        assert kwargs["model_name"] == "marengo3.0"
+        assert "video_file" in kwargs
+        return _FakeTask()
+
+    def wait_for_done(self, task_id):
+        assert task_id == "task-123"
+
+    def retrieve(self, task_id, embedding_option):
+        assert task_id == "task-123"
+        assert embedding_option == "visual"
+
+        class _R:
+            video_embedding = _FakeVideoEmbedding()
+
+        return _R()
+
+
+class _FakeEmbed:
+    def __init__(self):
+        self.tasks = _FakeEmbedTasks()
+
+    def create(self, model_name, text):
+        assert model_name == "marengo3.0"
+        assert isinstance(text, str)
+
+        class _R:
+            text_embedding = _FakeTextEmbedding()
+
+        return _R()
+
+
+class _FakeAnalyzeResult:
+    data = "A cyclist rides through a city street.\n<|endoftext|>"
+
+
+class _FakeClient:
+    def __init__(self):
+        self.embed = _FakeEmbed()
+
+    def analyze(self, model_name, video, prompt, max_tokens):
+        assert model_name == "pegasus1.5"
+        assert prompt
+        return _FakeAnalyzeResult()
+
+
+def test_tl_encode_string_query_shape():
+    out = tl_encode_string_query("a person riding a bicycle", _FakeClient())
+    assert tuple(out.shape) == (1, EMBED_DIM)
+
+
+def test_tl_encode_video_segments_shape():
+    out = tl_encode_video_segments(["seg-0.mp4", "seg-1.mp4"], _FakeClient())
+    # one vector per input video file, picking the "video"-scope embedding
+    assert tuple(out.shape) == (2, EMBED_DIM)
+
+
+def test_tl_segment_caption_cleans_output():
+    caption = tl_segment_caption(_FakeClient(), "https://example.com/clip.mp4", "Describe this clip")
+    assert "\n" not in caption
+    assert "<|endoftext|>" not in caption
+    assert caption.startswith("A cyclist")
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TWELVELABS_API_KEY"),
+    reason="TWELVELABS_API_KEY not set; skipping live Marengo call",
+)
+def test_marengo_text_embedding_live_512_dim():
+    from twelvelabs import TwelveLabs
+
+    client = TwelveLabs(api_key=os.environ["TWELVELABS_API_KEY"])
+    out = tl_encode_string_query("a person riding a bicycle", client)
+    assert tuple(out.shape) == (1, EMBED_DIM)

--- a/VideoRAG-algorithm/videorag/_storage/__init__.py
+++ b/VideoRAG-algorithm/videorag/_storage/__init__.py
@@ -2,4 +2,5 @@ from .gdb_networkx import NetworkXStorage
 from .gdb_neo4j import Neo4jStorage
 from .vdb_hnswlib import HNSWVectorStorage
 from .vdb_nanovectordb import NanoVectorDBStorage, NanoVectorDBVideoSegmentStorage
+from .vdb_twelvelabs import TwelveLabsVideoSegmentStorage
 from .kv_json import JsonKVStorage

--- a/VideoRAG-algorithm/videorag/_storage/vdb_twelvelabs.py
+++ b/VideoRAG-algorithm/videorag/_storage/vdb_twelvelabs.py
@@ -1,0 +1,116 @@
+import os
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+from nano_vectordb import NanoVectorDB
+from tqdm import tqdm
+
+from .._utils import logger
+from ..base import BaseVectorStorage
+from .._videoutil import tl_encode_video_segments, tl_encode_string_query
+
+
+@dataclass
+class TwelveLabsVideoSegmentStorage(BaseVectorStorage):
+    """Visual-retrieval index backed by TwelveLabs Marengo embeddings.
+
+    Drop-in replacement for ``NanoVectorDBVideoSegmentStorage``: video segments
+    and text queries are embedded into the same Marengo space, so retrieval is
+    plain cosine similarity over a ``nano-vectordb`` index, exactly like the
+    ImageBind path. The difference is that embedding happens via the TwelveLabs
+    API instead of a local ImageBind checkpoint, so visual retrieval no longer
+    needs a local GPU.
+
+    Enable it (opt-in, non-breaking) by overriding the storage class on
+    ``VideoRAG`` and setting the Marengo embedding dim (512)::
+
+        from videorag._storage import TwelveLabsVideoSegmentStorage
+
+        videorag = VideoRAG(
+            llm=openai_4o_mini_config,
+            vs_vector_db_storage_cls=TwelveLabsVideoSegmentStorage,
+            video_embedding_dim=512,
+            working_dir="./videorag-workdir",
+        )
+
+    Requires ``pip install twelvelabs`` and the ``TWELVELABS_API_KEY`` env var
+    (grab a free key at https://twelvelabs.io).
+    """
+
+    segment_retrieval_top_k: float = 2
+    embedding_model_name: str = "marengo3.0"
+
+    def __post_init__(self):
+        self._client_file_name = os.path.join(
+            self.global_config["working_dir"], f"vdb_{self.namespace}.json"
+        )
+        self._client = NanoVectorDB(
+            self.global_config["video_embedding_dim"], storage_file=self._client_file_name
+        )
+        self.top_k = self.global_config.get(
+            "segment_retrieval_top_k", self.segment_retrieval_top_k
+        )
+        self.embedding_model_name = self.global_config.get(
+            "tl_embedding_model_name", self.embedding_model_name
+        )
+        self._tl_client = self._get_tl_client()
+
+    def _get_tl_client(self):
+        from twelvelabs import TwelveLabs
+
+        api_key = os.environ.get("TWELVELABS_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "TWELVELABS_API_KEY is not set. Get a free key at https://twelvelabs.io"
+            )
+        return TwelveLabs(api_key=api_key)
+
+    async def upsert(self, video_name, segment_index2name, video_output_format):
+        logger.info(f"Inserting {len(segment_index2name)} segments to {self.namespace}")
+        if not len(segment_index2name):
+            logger.warning("You insert an empty data to vector DB")
+            return []
+        list_data, video_paths = [], []
+        cache_path = os.path.join(self.global_config["working_dir"], "_cache", video_name)
+        index_list = list(segment_index2name.keys())
+        for index in index_list:
+            list_data.append(
+                {
+                    "__id__": f"{video_name}_{index}",
+                    "__video_name__": video_name,
+                    "__index__": index,
+                }
+            )
+            segment_name = segment_index2name[index]
+            video_file = os.path.join(cache_path, f"{segment_name}.{video_output_format}")
+            video_paths.append(video_file)
+        embeddings = []
+        for video_path in tqdm(video_paths, desc=f"Encoding Video Segments {video_name}"):
+            batch_embeddings = tl_encode_video_segments(
+                [video_path], self._tl_client, self.embedding_model_name
+            )
+            embeddings.append(batch_embeddings)
+        embeddings = torch.concat(embeddings, dim=0).numpy()
+        for i, d in enumerate(list_data):
+            d["__vector__"] = embeddings[i]
+        results = self._client.upsert(datas=list_data)
+        return results
+
+    async def query(self, query: str):
+        embedding = tl_encode_string_query(
+            query, self._tl_client, self.embedding_model_name
+        )
+        embedding = embedding[0].numpy()
+        results = self._client.query(
+            query=embedding,
+            top_k=self.top_k,
+            better_than_threshold=-1,
+        )
+        results = [
+            {**dp, "id": dp["__id__"], "distance": dp["__metrics__"]} for dp in results
+        ]
+        return results
+
+    async def index_done_callback(self):
+        self._client.save()

--- a/VideoRAG-algorithm/videorag/_videoutil/__init__.py
+++ b/VideoRAG-algorithm/videorag/_videoutil/__init__.py
@@ -1,4 +1,4 @@
 from .split import split_video, saving_video_segments
 from .asr import speech_to_text
-from .caption import segment_caption, merge_segment_information, retrieved_segment_caption
-from .feature import encode_video_segments, encode_string_query
+from .caption import segment_caption, merge_segment_information, retrieved_segment_caption, tl_segment_caption
+from .feature import encode_video_segments, encode_string_query, tl_encode_video_segments, tl_encode_string_query

--- a/VideoRAG-algorithm/videorag/_videoutil/caption.py
+++ b/VideoRAG-algorithm/videorag/_videoutil/caption.py
@@ -84,5 +84,29 @@ def retrieved_segment_caption(caption_model, caption_tokenizer, refine_knowledge
         this_caption = segment_caption.replace("\n", "").replace("<|endoftext|>", "")
         caption_result[this_segment] = f"Caption:\n{this_caption}\nTranscript:\n{segment_transcript}\n\n"
         torch.cuda.empty_cache()
-    
+
     return caption_result
+
+
+# ---------------------------------------------------------------------------
+# TwelveLabs Pegasus captioning (optional, cloud-based alternative to MiniCPM-V)
+#
+# Pegasus reads the video pixels directly (no frame sampling here) and returns a
+# natural-language description, so it can replace the local MiniCPM-V caption
+# model for clip-level captioning / QA. ``video`` is a TwelveLabs VideoContext
+# (e.g. a public URL or an uploaded asset id). This avoids the local GPU /
+# MiniCPM-V checkpoint requirement for captioning.
+# ---------------------------------------------------------------------------
+def tl_segment_caption(client, video, prompt: str, model_name: str = "pegasus1.5", max_tokens: int = 2048):
+    """Caption / analyze a single video clip with Pegasus.
+
+    Returns the cleaned caption string, matching the post-processing applied to
+    the MiniCPM-V captions above.
+    """
+    result = client.analyze(
+        model_name=model_name,
+        video=video,
+        prompt=prompt,
+        max_tokens=max_tokens,
+    )
+    return result.data.replace("\n", "").replace("<|endoftext|>", "")

--- a/VideoRAG-algorithm/videorag/_videoutil/feature.py
+++ b/VideoRAG-algorithm/videorag/_videoutil/feature.py
@@ -26,3 +26,48 @@ def encode_string_query(query:str, embedder: ImageBindModel):
         embeddings = embedder(inputs)[ModalityType.TEXT]
     embeddings = embeddings.cpu()
     return embeddings
+
+
+# ---------------------------------------------------------------------------
+# TwelveLabs Marengo embeddings (optional, cloud-based alternative to ImageBind)
+#
+# Marengo produces video-segment and text-query embeddings in a *shared* 512-d
+# space, so it is a drop-in replacement for the ImageBind functions above: video
+# clips and text queries can be compared directly with cosine similarity. Using
+# it removes the local GPU / ImageBind checkpoint requirement for visual
+# retrieval. Enabled by selecting ``TwelveLabsVideoSegmentStorage`` as the video
+# segment feature store (see ``videorag/_storage/vdb_twelvelabs.py``).
+# ---------------------------------------------------------------------------
+def tl_encode_video_segments(video_paths, client, model_name: str = "marengo3.0"):
+    """Embed each video-segment file with Marengo.
+
+    Returns a ``torch.Tensor`` of shape ``(len(video_paths), embedding_dim)``,
+    matching ``encode_video_segments`` so it can feed the same vector DB.
+    """
+    embeddings = []
+    for video_path in video_paths:
+        task = client.embed.tasks.create(
+            model_name=model_name,
+            video_file=video_path,
+            video_embedding_scope=["clip", "video"],
+        )
+        client.embed.tasks.wait_for_done(task_id=task.id)
+        result = client.embed.tasks.retrieve(task_id=task.id, embedding_option="visual")
+        segments = result.video_embedding.segments
+        # One vector per segment file: use the whole-video ("video" scope) vector
+        # when present, otherwise average the clip vectors.
+        video_scope = [s.float_ for s in segments if s.embedding_scope == "video"]
+        vectors = video_scope if video_scope else [s.float_ for s in segments]
+        embeddings.append(torch.tensor(vectors, dtype=torch.float32).mean(dim=0))
+    return torch.stack(embeddings, dim=0)
+
+
+def tl_encode_string_query(query: str, client, model_name: str = "marengo3.0"):
+    """Embed a text query with Marengo into the shared video/text space.
+
+    Returns a ``torch.Tensor`` of shape ``(1, embedding_dim)``, matching
+    ``encode_string_query``.
+    """
+    result = client.embed.create(model_name=model_name, text=query)
+    vector = result.text_embedding.segments[0].float_
+    return torch.tensor([vector], dtype=torch.float32)


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds **optional, opt-in** support for [TwelveLabs](https://twelvelabs.io) cloud video understanding to the VideoRAG pipeline, alongside the existing Ollama / DeepSeek / OpenAI options.

### What it adds
- **Marengo embeddings as a drop-in visual retrieval index.** `TwelveLabsVideoSegmentStorage` (in `videorag/_storage/vdb_twelvelabs.py`) mirrors `NanoVectorDBVideoSegmentStorage` exactly, but embeds video segments and text queries into Marengo's shared 512-d space. Video clips and queries are still compared with plain cosine similarity over `nano-vectordb`, so nothing downstream changes — it just removes the local GPU / ImageBind checkpoint requirement for visual retrieval.
- **Pegasus for clip-level captioning / QA.** `tl_segment_caption` (in `videorag/_videoutil/caption.py`) reads the video directly and returns a natural-language caption, a cloud alternative to the local MiniCPM-V caption model. Output post-processing matches the existing captions.

### Why it helps
VideoRAG already supports swapping the LLM/embedding backend per provider; this extends the same idea to the *visual* layer, letting users run the visual index and captioning without a local 24GB GPU / ImageBind + MiniCPM-V checkpoints.

### Opt-in / non-breaking
Defaults are completely unchanged. You only touch TwelveLabs by passing `vs_vector_db_storage_cls=TwelveLabsVideoSegmentStorage` (and `video_embedding_dim=512`) or calling `tl_segment_caption` explicitly. The `twelvelabs` SDK is imported lazily inside the storage class, so `import videorag` still works with the SDK absent.

### How it was tested
- `tests/test_twelvelabs.py`: no-network unit tests (fake client) asserting the Marengo video/query embedding shapes and Pegasus caption cleanup, plus a live test gated on `TWELVELABS_API_KEY`.
- Verified the live Marengo text-embedding call returns a **512-d** vector. All 4 tests pass.

### Docs / deps
Added a "TwelveLabs Support" section to `VideoRAG-algorithm/README.md` and listed `twelvelabs>=1.2.8` as an optional dependency.

Note: this targets the canonical `VideoRAG-algorithm/videorag` package; I left the vendored `Vimo-desktop/python_backend` copy untouched to keep the diff focused — happy to mirror it there too if you'd like.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
